### PR TITLE
Add initial PromiseRegistry implementation

### DIFF
--- a/Monal/Classes/ChangePassword.swift
+++ b/Monal/Classes/ChangePassword.swift
@@ -55,7 +55,6 @@ struct ChangePassword: View {
         }
         .done { _ in
             successAlert(title: Text("Success"), message: Text("The password has been changed"))
-            MLXMPPManager.sharedInstance().updatePassword(newPass, forAccount: accountID)
         }
         .catch { error in
             errorAlert(title: Text("Error"), message: Text(error.localizedDescription))

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -909,6 +909,11 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         [OmemoState class],
         [MLContactSoftwareVersionInfo class],
         [Quicksy_Country class],
+        [NSUUID class],
+        [MLPromise class],
+        [MLSerializablePromise class],
+        [MLPromiseRegistry class],
+        [NSNull class],
     ]] fromData:data error:&error];
     if(error)
         @throw [NSException exceptionWithName:@"NSError" reason:[NSString stringWithFormat:@"%@", error] userInfo:@{@"error": error}];

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -12,6 +12,7 @@
 #import "MLHandler.h"
 #import "DataLayer.h"
 #import "MLImageManager.h"
+#import "MLXMPPManager.h"
 #import "HelperTools.h"
 #import "MLNotificationQueue.h"
 #import "MLContactSoftwareVersionInfo.h"
@@ -782,6 +783,20 @@ $$class_handler(handleModerationResponse, $$ID(xmpp*, account), $$ID(XMPPIQ*, iq
     [[MLNotificationQueue currentQueue] postNotificationName:kMonalContactRefresh object:account userInfo:@{
         @"contact": msg.contact,
     }];
+$$
+
+$$class_handler(handleChangePassword, $$ID(xmpp*, account), $$ID(NSString*, newPass), $$ID(NSUUID*, uuid))
+    DDLogDebug(@"Handling password change");
+    [[MLXMPPManager sharedInstance] updatePassword:newPass forAccount:account.accountID];
+    MLPromise* promise = [account.promiseRegistry getPromise:uuid];
+    [promise resolve:nil];
+$$
+
+$$class_handler(handleChangePasswordInvalidation, $$ID(xmpp*, account), $$ID(NSUUID*, uuid))
+    DDLogDebug(@"Invalidating password change");
+    NSError* error = [NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Could not change password"}];
+    MLPromise* promise = [account.promiseRegistry getPromise:uuid];
+    [promise resolve:error];
 $$
 
 #ifdef IS_QUICKSY

--- a/Monal/Classes/MLPromiseRegistry.h
+++ b/Monal/Classes/MLPromiseRegistry.h
@@ -1,0 +1,48 @@
+//
+//  MLPromiseRegistry.h
+//  Monal
+//
+//  Created by Matthew Fennell on 29/09/2024.
+//  Copyright © 2024 monal-im.org. All rights reserved.
+//
+
+#import "MLConstants.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MLPromiseRegistry;
+typedef void (^PromiseResolverCallback)(NSUUID*);
+
+@interface MLSerializablePromise : NSObject <NSSecureCoding>
+
+@property(readonly, strong) NSUUID* uuid;
+@property(nonatomic, strong) id resolveArg;
+@property(nonatomic, assign) BOOL isResolved;
+
+-(void) resolve:(id _Nullable) arg;
+
+@end
+
+@interface MLPromise : NSObject <NSSecureCoding>
+
+-(instancetype) initWithCallback:(PromiseResolverCallback) promiseResolverCallback andPromiseRegistry:(MLPromiseRegistry*) promiseRegisry;
+-(instancetype) initEmptyPromiseWithPromiseRegistry:(MLPromiseRegistry*) promiseRegistry;
+-(instancetype) initWithSerializablePromise:(MLSerializablePromise*) serializablePromise andPromiseRegistry:(MLPromiseRegistry*) promiseRegistry;
+
+-(void) resolve:(id _Nullable) arg;
+-(AnyPromise*) toPromise;
+-(void) attemptConsume;
+
+@end
+
+@interface MLPromiseRegistry : NSObject <NSSecureCoding>
+
+-(NSUUID*) addPromise:(MLPromise*) promise;
+-(void) removePromise:(NSUUID*) uuid;
+-(MLPromise*) getPromise:(NSUUID*) uuid;
+-(void) attemptConsumeRemainingPromises;
+-(void) sync:(MLPromiseRegistry*) other;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Monal/Classes/MLPromiseRegistry.m
+++ b/Monal/Classes/MLPromiseRegistry.m
@@ -1,0 +1,260 @@
+//
+//  MLPromiseRegistry.m
+//  monalxmpp
+//
+//  Created by Matthew Fennell on 29/09/2024.
+//  Copyright © 2024 monal-im.org. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "HelperTools.h"
+#import "MLPromiseRegistry.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation MLSerializablePromise
+
+-(instancetype) init
+{
+    _uuid = [NSUUID UUID];
+    _isResolved = false;
+    return self;
+}
+
+-(void) resolve:(id _Nullable) arg
+{
+    _resolveArg = arg;
+    _isResolved = true;
+}
+
++(BOOL) supportsSecureCoding
+{
+    return YES;
+}
+
+-(void) encodeWithCoder:(NSCoder*) coder
+{
+    [coder encodeObject:_uuid forKey:@"uuid"];
+    [coder encodeObject:_resolveArg forKey:@"resolveArg"];
+    [coder encodeBool:_isResolved forKey:@"isResolved"];
+}
+
+-(nullable instancetype) initWithCoder:(NSCoder*) coder
+{
+    self = [self init];
+    _uuid = [coder decodeObjectForKey:@"uuid"];
+    _resolveArg = [coder decodeObjectForKey:@"resolveArg"];
+    _isResolved = [coder decodeBoolForKey:@"isResolved"];
+    return self;
+}
+
+@end
+
+@interface MLPromise()
+
+@property(nonatomic, strong) MLSerializablePromise* serializablePromise;
+
+@property(nonatomic, weak) MLPromiseRegistry* promiseRegistry;
+
+@property(nonatomic, strong) PromiseResolverCallback promiseResolverCallback;
+@property(nonatomic, strong) PMKResolver onConsumeCallback;
+
+@property(nonatomic, strong) AnyPromise* promise;
+
+@end
+
+@implementation MLPromise
+
+-(instancetype) initWithCallback:(PromiseResolverCallback) promiseResolverCallback andPromiseRegistry:(MLPromiseRegistry*) promiseRegistry
+{
+    _serializablePromise = [MLSerializablePromise new];
+    _promiseResolverCallback = promiseResolverCallback;
+    _promiseRegistry = promiseRegistry;
+    [promiseRegistry addPromise:self];
+    return self;
+}
+
+-(instancetype) initWithSerializablePromise:(MLSerializablePromise*) serializablePromise andPromiseRegistry:(MLPromiseRegistry*) promiseRegistry
+{
+    _serializablePromise = serializablePromise;
+    _promiseResolverCallback = ^(NSUUID* uuid) {};
+    _onConsumeCallback = ^(PMKResolver resolve) {};
+    _promiseRegistry = promiseRegistry;
+    [promiseRegistry addPromise:self];
+    return self;
+}
+
+-(instancetype) initEmptyPromiseWithPromiseRegistry:(MLPromiseRegistry*) promiseRegistry
+{
+    _serializablePromise = [MLSerializablePromise new];
+    _promiseResolverCallback = ^(NSUUID* uuid) {};
+    _onConsumeCallback = ^(PMKResolver resolve) {};
+    _promiseRegistry = promiseRegistry;
+    [_promiseRegistry addPromise:self];
+    return self;
+}
+
+-(NSUUID*) uuid
+{
+    return _serializablePromise.uuid;
+}
+
+-(id) resolveArg
+{
+    return _serializablePromise.resolveArg;
+}
+
+-(BOOL) isResolved
+{
+    return _serializablePromise.isResolved;
+}
+
+-(void) resolve:(id _Nullable) arg
+{
+    DDLogDebug(@"Resolving promise %@ with arg %@", self.uuid, arg);
+    NSAssert(!self.isResolved, @"Trying to resolve an already resolved promise");
+
+    [_serializablePromise resolve:arg];
+    [self attemptConsume];
+}
+
+-(AnyPromise*) toPromise
+{
+    DDLogDebug(@"Converting MLPromise %@ to AnyPromise", self.uuid);
+
+    if(_promise != nil)
+    {
+        DDLogDebug(@"Returning already existing AnyPromise");
+        return _promise;
+    }
+
+    _promise = [AnyPromise promiseWithResolverBlock:^(PMKResolver onConsumeCallback) {
+        self.onConsumeCallback = onConsumeCallback;
+        self.promiseResolverCallback(self.uuid);
+    }];
+
+    return _promise;
+}
+
+-(void) attemptConsume
+{
+    DDLogDebug(@"Intend to consume promise %@ with arg %@", self.uuid, self.resolveArg);
+
+    if([HelperTools isAppExtension])
+    {
+        DDLogDebug(@"Not consuming promise %@ as we are in the app extension", self.uuid);
+    }
+
+    if(!self.isResolved) {
+        DDLogDebug(@"Not consuming promise %@ as it has not been resolved yet", self.uuid);
+        return;
+    }
+
+    _onConsumeCallback(self.resolveArg);
+    [_promiseRegistry removePromise:self.uuid];
+}
+
++(BOOL) supportsSecureCoding
+{
+    return YES;
+}
+
+-(void) encodeWithCoder:(NSCoder*) coder
+{
+    [coder encodeObject:_serializablePromise forKey:@"serializablePromise"];
+}
+
+-(nullable instancetype) initWithCoder:(NSCoder*) coder
+{
+    self = [self init];
+    _serializablePromise = [coder decodeObjectForKey:@"serializablePromise"];
+    return self;
+}
+
+@end
+
+@interface MLPromiseRegistry()
+
+@property(atomic, strong) NSMutableDictionary<NSUUID*, MLPromise*>* promises;
+
+@end
+
+@implementation MLPromiseRegistry
+
+-(instancetype) init
+{
+    _promises = [NSMutableDictionary new];
+    return self;
+}
+
+-(NSUUID*) addPromise:(MLPromise*) promise
+{
+    [_promises setObject:promise forKey:promise.uuid];
+    DDLogDebug(@"After adding %@, promise map contains: %@", promise.uuid, [_promises allKeys]);
+    return promise.uuid;
+}
+
+-(void) removePromise:(NSUUID*) uuid
+{
+    [_promises removeObjectForKey:uuid];
+    DDLogDebug(@"After removing %@, promise map contains: %@", uuid, [_promises allKeys]);
+}
+
+-(MLPromise*) getPromise:(NSUUID*) uuid
+{
+    DDLogDebug(@"Getting promise %@, promise map contains: %@", uuid, [_promises allKeys]);
+    MLPromise* promise = _promises[uuid];
+    if(promise == nil)
+    {
+        DDLogError(@"Tried to get promise %@ which does not exist. Returning empty promise", uuid);
+        return [[MLPromise alloc] initEmptyPromiseWithPromiseRegistry:self];
+    }
+    return promise;
+}
+
+-(void) attemptConsumeRemainingPromises
+{
+    for(MLPromise* promise in [_promises allValues])
+    {
+        [promise attemptConsume];
+    }
+}
+
+-(void) sync:(MLPromiseRegistry*) other
+{
+    DDLogDebug(@"Syncing our promises %@ with their promises %@", [_promises allKeys], [other.promises allKeys]);
+    for(MLPromise* otherPromise in [other.promises allValues])
+    {
+        if(_promises[otherPromise.uuid] != nil)
+        {
+            _promises[otherPromise.uuid].serializablePromise = otherPromise.serializablePromise;
+        }
+        else
+        {
+            _promises[otherPromise.uuid] = [[MLPromise alloc] initWithSerializablePromise:otherPromise.serializablePromise andPromiseRegistry:self];
+        }
+    }
+    DDLogDebug(@"Promises after sync: %@", [_promises allKeys]);
+}
+
++(BOOL) supportsSecureCoding
+{
+    return YES;
+}
+
+-(void) encodeWithCoder:(NSCoder*) coder
+{
+    [coder encodeObject:_promises forKey:@"promises"];
+}
+
+-(nullable instancetype) initWithCoder:(NSCoder*) coder
+{
+    self = [self init];
+    _promises = [coder decodeObjectForKey:@"promises"];
+    return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -15,6 +15,7 @@
 #import "MLContact.h"
 
 #import "MLXMPPConnection.h"
+#import "MLPromiseRegistry.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -96,6 +97,7 @@ typedef void (^monal_iq_handler_t)(XMPPIQ* _Nullable);
 @property (nonatomic, strong) MLOMEMO* omemo;
 @property (nonatomic, strong) MLPubSub* pubsub;
 @property (nonatomic, strong) MLMucProcessor* mucProcessor;
+@property (nonatomic, strong) MLPromiseRegistry* promiseRegistry;
 
 //calculated
 @property (nonatomic, strong) NSDate* connectedTime;

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		26E8462824EABAED00ECE419 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 26E8462A24EABAED00ECE419 /* Main.storyboard */; };
 		26F9794D1ACAC73A0008E005 /* MLContactCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F9794C1ACAC73A0008E005 /* MLContactCell.xib */; };
 		26FE3BCB1C61A6C3003CC230 /* MLResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26FE3BCA1C61A6C3003CC230 /* MLResizingTextView.m */; };
+		341F44662CAF427500AA6C7D /* MLPromiseRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 341F44642CAF427500AA6C7D /* MLPromiseRegistry.h */; };
+		341F44672CAF427500AA6C7D /* MLPromiseRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 341F44652CAF427500AA6C7D /* MLPromiseRegistry.m */; };
 		34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */; };
 		34E58B4B2C68E7BC009A1634 /* ContactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E58B4A2C68E7BC009A1634 /* ContactsView.swift */; };
 		38720923251EDE07001837EB /* MLXEPSlashMeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */; };
@@ -496,6 +498,8 @@
 		2C59BAF969550DFAC27E5F2B /* Pods_MonalXMPPUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MonalXMPPUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E5021A8D40FCC591D952104 /* Pods-NotificaionService.alpha-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificaionService.alpha-ios.xcconfig"; path = "Target Support Files/Pods-NotificaionService/Pods-NotificaionService.alpha-ios.xcconfig"; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* MonalSourceCodePrefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MonalSourceCodePrefix.pch; sourceTree = "<group>"; };
+		341F44642CAF427500AA6C7D /* MLPromiseRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MLPromiseRegistry.h; sourceTree = "<group>"; };
+		341F44652CAF427500AA6C7D /* MLPromiseRegistry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLPromiseRegistry.m; sourceTree = "<group>"; };
 		34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableShimView.swift; sourceTree = "<group>"; };
 		34E58B4A2C68E7BC009A1634 /* ContactsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsView.swift; sourceTree = "<group>"; };
 		3872091F251EDE07001837EB /* MLXEPSlashMeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLXEPSlashMeHandler.h; sourceTree = "<group>"; };
@@ -858,6 +862,8 @@
 				262D9EAB17924532009292B4 /* MLConstants.h */,
 				26EC411117BDE39E0031304D /* MLImageManager.h */,
 				26EC411217BDE39E0031304D /* MLImageManager.m */,
+				341F44642CAF427500AA6C7D /* MLPromiseRegistry.h */,
+				341F44652CAF427500AA6C7D /* MLPromiseRegistry.m */,
 				263AFDFA209B3B35007F9CEE /* MLSignalStore.h */,
 				263AFDFB209B3B35007F9CEE /* MLSignalStore.m */,
 				C16D18332792A4AF00F869A0 /* DataLayerMigrations.h */,
@@ -1505,6 +1511,7 @@
 				26D4389123A5EB6C00242AAA /* MLConstants.h in Headers */,
 				C158D40025A0AB810005AA40 /* MLMucProcessor.h in Headers */,
 				54A22D2D26185E7E00B56EAD /* MLNotificationQueue.h in Headers */,
+				341F44662CAF427500AA6C7D /* MLPromiseRegistry.h in Headers */,
 				541E4CC4254D369200FD7B28 /* MLPubSubProcessor.h in Headers */,
 				844921EC2C29F9BE00B99A9C /* MLDelayableTimer.h in Headers */,
 				84C1CD542A8F6196007076ED /* MLStreamRedirect.h in Headers */,
@@ -2161,6 +2168,7 @@
 			files = (
 				5427C94E276A6BE1003217D5 /* UIColor+Extension.m in Sources */,
 				540E13A524CF6A8C0038FDA0 /* MLNotificationManager.m in Sources */,
+				341F44672CAF427500AA6C7D /* MLPromiseRegistry.m in Sources */,
 				54D2308424CB10EE00638D65 /* MLLogFileManager.m in Sources */,
 				26CC57B323A086CC00ABB92A /* XMPPIQ.m in Sources */,
 				C1613B5B2520723D0062C0C2 /* MLBasePaser.m in Sources */,


### PR DESCRIPTION
Initial draft PR for [this comment](https://github.com/monal-im/Monal/pull/1183#issuecomment-2378317049). Sorry it's taken so long!

Todolist:

- [x] Properly test in bad network conditions - swipe app away before reply from backend is received
Conclusion: it doesn't help if the connection/stream gets closed, as on resuming the stream Monal will still be using the old password, and the connection will fail.
To fix this, we could store a set of passwords in the keychain and try each one until we find the vaild one (and mark it as the only password).
- [x] Persist and load the promise registry UUIDS `realPersistState` and `realReadState`, so that the extension can mark promises as handled.
- [ ] Properly handle errors from the server - add a parameter in the handlers to get the reply